### PR TITLE
Make header parser more resilient

### DIFF
--- a/stats/src/display.ts
+++ b/stats/src/display.ts
@@ -379,11 +379,11 @@ interface UsageReportRowData {
   realp: number;
 }
 
-function parseUsageReport(report: string) {
+export function parseUsageReport(report: string) {
   const usage: {[id: string]: UsageReportRowData} = {};
   const lines = report.split('\n');
-  const battles = Number(lines[0].slice(16));
-  const avg = Number(lines[1].slice(19));
+  const battles = Number(lines[0].split(': ')[1]);
+  const avg = Number(lines[1].split(': ')[1]);
 
   for (let i = 5; i < lines.length; i++) {
     const line = lines[i].split('|');
@@ -406,10 +406,10 @@ interface LeadsReportRowData {
   rawp: number;
 }
 
-function parseLeadsReport(report: string) {
+export function parseLeadsReport(report: string) {
   const usage: {[id: string]: LeadsReportRowData} = {};
   const lines = report.split('\n');
-  const total = Number(lines[0].slice(13));
+  const total = Number(lines[0].split(': ')[1]);
 
   for (let i = 4; i < lines.length; i++) {
     const line = lines[i].split('|');

--- a/stats/src/display.ts
+++ b/stats/src/display.ts
@@ -75,7 +75,8 @@ export interface DetailedMovesetStatistics {
   // n = sum(POKE1_KOED...DOUBLE_SWITCH)
   // p = POKE1_KOED + POKE1_SWITCHED_OUT / n
   // d = sqrt((p * (1 - p)) / n)
-  'Checks and Counters': {[pokemon: string]: [number, number, number]};
+  // Old format (pre-2026-03): [n, p, d] array. New format: {n, p, d} object.
+  'Checks and Counters': {[pokemon: string]: [number, number, number] | {n: number; p: number; d: number}};
 }
 
 // Corrections for Pokémon who have had their names changed over time by developers.
@@ -210,8 +211,9 @@ export const Display = new class {
       }
 
       const scored: {[name: string]: {score: number; val: [number, number, number]}} = {};
-      for (const [k, [n]] of Object.entries(p['Checks and Counters'])) {
+      for (const [k, v] of Object.entries(p['Checks and Counters'])) {
         if (!outcomes[k]) continue;
+        const n = Array.isArray(v) ? v[0] : v.n;
         const {koedn, switchedn} = outcomes[k];
         const q = R((koedn * n + switchedn * n) / n);
         const d = R(Math.sqrt((q * (1.0 - q)) / n));

--- a/stats/src/test/display.test.ts
+++ b/stats/src/test/display.test.ts
@@ -1,0 +1,90 @@
+import {parseLeadsReport, parseUsageReport} from '../display';
+
+// Old format: leading space on header lines, Real column has actual values.
+// New format (introduced 2026-03): no leading space, Real column is always 0.
+
+const OLD_USAGE = [
+  ' Total battles: 218',
+  ' Avg. weight/team: 1.0',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ------ + ------- + ',
+  ' | Rank | Pokemon            | Usage %   | Raw    | %       | Real   | %       | ',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ------ + ------- + ',
+  ' | 1    | Greninja           | 16.51376% | 72     | 16.514% | 49     | 18.980% | ',
+  ' | 2    | Incineroar         | 14.22018% | 62     | 14.220% | 38     | 14.719% | ',
+].join('\n');
+
+const NEW_USAGE = [
+  'Total battles: 423',
+  'Avg. weight/team: 1.000',
+  '+ ---- + ------------------ + --------- + ------ + ------- + ------ + ------- +',
+  '| Rank | Pokemon            | Usage %   | Raw    | %       | Real   | %       |',
+  '+ ---- + ------------------ + --------- + ------ + ------- + ------ + ------- +',
+  '| 1    | Rillaboom          | 16.78487% | 142    | 16.785% | 0      |  0.000% |',
+  '| 2    | Incineroar         | 16.19385% | 137    | 16.194% | 0      |  0.000% |',
+].join('\n');
+
+const OLD_LEADS = [
+  ' Total leads: 6',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ',
+  ' | Rank | Pokemon            | Usage %   | Raw    | %       | ',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ',
+  ' | 1    | Ogerpon            | 16.66667% | 1      | 16.667% | ',
+].join('\n');
+
+const NEW_LEADS = [
+  'Total leads: 6',
+  '+ ---- + ------------------ + --------- + ------ + ------- +',
+  '| Rank | Pokemon            | Usage %   | Raw    | %       |',
+  '+ ---- + ------------------ + --------- + ------ + ------- +',
+  '| 1    | Ogerpon            | 16.66667% | 1      | 16.667% |',
+].join('\n');
+
+describe('parseUsageReport', () => {
+  test('old format (leading space header)', () => {
+    const r = parseUsageReport(OLD_USAGE);
+    expect(r.battles).toBe(218);
+    expect(r.avg).toBe(1.0);
+    expect(r.usage['greninja']).toMatchObject({
+      weightedp: expect.closeTo(0.1651376),
+      raw: 72,
+      rawp: expect.closeTo(0.16514),
+      real: 49,
+      realp: expect.closeTo(0.1898),
+    });
+  });
+
+  test('new format (no leading space, real=0)', () => {
+    const r = parseUsageReport(NEW_USAGE);
+    expect(r.battles).toBe(423);
+    expect(r.avg).toBe(1.0);
+    expect(r.usage['rillaboom']).toMatchObject({
+      weightedp: expect.closeTo(0.1678487),
+      raw: 142,
+      rawp: expect.closeTo(0.16785),
+      real: 0,
+      realp: 0,
+    });
+  });
+});
+
+describe('parseLeadsReport', () => {
+  test('old format (leading space header)', () => {
+    const r = parseLeadsReport(OLD_LEADS);
+    expect(r.total).toBe(6);
+    expect(r.usage['ogerpon']).toMatchObject({
+      weightedp: expect.closeTo(0.1666667),
+      raw: 1,
+      rawp: expect.closeTo(0.16667),
+    });
+  });
+
+  test('new format (no leading space)', () => {
+    const r = parseLeadsReport(NEW_LEADS);
+    expect(r.total).toBe(6);
+    expect(r.usage['ogerpon']).toMatchObject({
+      weightedp: expect.closeTo(0.1666667),
+      raw: 1,
+      rawp: expect.closeTo(0.16667),
+    });
+  });
+});

--- a/stats/src/test/display.test.ts
+++ b/stats/src/test/display.test.ts
@@ -1,4 +1,4 @@
-import {parseLeadsReport, parseUsageReport} from '../display';
+import {Display, parseLeadsReport, parseUsageReport} from '../display';
 
 // Old format: leading space on header lines, Real column has actual values.
 // New format (introduced 2026-03): no leading space, Real column is always 0.
@@ -86,5 +86,77 @@ describe('parseLeadsReport', () => {
       raw: 1,
       rawp: expect.closeTo(0.16667),
     });
+  });
+});
+
+const MOVESETS = [
+  ' +---+',
+  ' | Snorlax  |',
+  ' +---+',
+  ' | Raw count: 2  |',
+  ' | Avg. weight: 1.0  |',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' | Checks and Counters |',
+  ' | Tauros 1.0 (1.00±0.00) |',
+  ' |  (100.0% KOed / 0.0% switched out) |',
+].join('\n');
+
+const USAGE_REPORT = [
+  ' Total battles: 1',
+  ' Avg. weight/team: 1.0',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ------ + ------- + ',
+  ' | Rank | Pokemon            | Usage %   | Raw    | %       | Real   | %       | ',
+  ' + ---- + ------------------ + --------- + ------ + ------- + ------ + ------- + ',
+  ' | 1    | Snorlax            | 100.0000% | 2      | 100.000%| 2      | 100.000%| ',
+].join('\n');
+
+const BASE_POKEMON = {
+  'Raw count': 2,
+  usage: 1.0,
+  'Viability Ceiling': [2, 89, 89, 89] as [number, number, number, number],
+  Abilities: {illuminate: 2},
+  Items: {nothing: 2},
+  'Tera Types': {nothing: 2},
+  Spreads: {'Serious:252/252/252/252/252/252': 2},
+  Moves: {bodyslam: 2},
+  Teammates: {},
+};
+
+const BASE_DETAILED = {
+  info: {
+    metagame: 'gen1ou', cutoff: 0, 'cutoff deviation': 0 as 0,
+    'team type': null, 'number of battles': 1,
+  },
+  data: {Snorlax: {...BASE_POKEMON, 'Checks and Counters': {} as any}},
+};
+
+// gen mock: all lookups return undefined so names fall back to their raw values
+const mockGen = {
+  species: {get: () => undefined},
+  abilities: {get: () => undefined},
+  items: {get: () => undefined},
+  moves: {get: () => undefined},
+} as any;
+
+// Checks and Counters format changed in 2026-03 from [n, p, d] arrays to {n, p, d} objects.
+// https://www.smogon.com/stats/2026-02/chaos/gen9ou-1825.json (old)
+// https://www.smogon.com/stats/2026-03/chaos/gen9ou-1825.json (new)
+describe('Display.fromReports — Checks and Counters format', () => {
+  test.each([
+    ['old: [n, p, d] array', {Tauros: [1, 1.0, 0.0]}],
+    ['new (2026-03): {n, p, d} object', {Tauros: {n: 1, p: 1.0, d: 0.0}}],
+  ] as const)('%s', (_, cnc) => {
+    const detailed = JSON.stringify({
+      ...BASE_DETAILED,
+      data: {Snorlax: {...BASE_POKEMON, 'Checks and Counters': cnc}},
+    });
+    const result = Display.fromReports(mockGen, USAGE_REPORT, MOVESETS, detailed);
+    expect(result.pokemon['Snorlax'].counters).toEqual({Tauros: [1, 1, 0]});
   });
 });


### PR DESCRIPTION
**Please describe your fix:**

Don't rely on the headers being always in the same place

**Bug:**

The stats lost a trailing space they used to have

Regression from https://github.com/smogon/usage-stats/commit/1aa1ec9806c950d9b96c7c7cd37e4bb244415d72#diff-27f1a58a5e1a263a3bb493ee95a5aabe5b9db8620da74217f5251e91c15f5489

**Testing:**

Added some tests. As a disclaimer, they were written by Claude. They pass red-green.

I had to export some functions for testing, not sure if that is an API change

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] N/A I have made corresponding changes to the documentation where necessary
- [X] My changes generate no new warnings
- [ ] N/A Any dependent changes have been merged and published in downstream modules
- [X] I have split off unrelated changes into their own PRs and done my best to make this PR as
      focused as possible while still being useful