### PR TITLE
Fully handle 2026-03 moveset/metagame report format changes

### DIFF
--- a/stats/src/display.ts
+++ b/stats/src/display.ts
@@ -86,7 +86,7 @@ const FIX: {[id: string]: string} = {
   mimikyutotembusted: 'mimikyubustedtotem',
 };
 
-const SPECIES = /\| (.*) [-+.0-9]+ \([-+.0-9]+±[-+.0-9]+\)/;
+const SPECIES = /\| (.*?) [-+.0-9]+ \([^)]+\)/;
 const OUTCOME = /\|\W+\(([-+.0-9]+)% KOed \/ ([-+.0-9]+)% switched out\)/;
 
 export const Display = new class {
@@ -428,32 +428,45 @@ export function parseLeadsReport(report: string) {
   return {total, usage};
 }
 
-function partialParseMovesetReport(report: string) {
+export function partialParseMovesetReport(report: string) {
   const movesets: {
     [name: string]: {
       weight: number;
       outcomes: {[species: string]: {koedn: number; switchedn: number}};
     };
   } = {};
-  let section = 0;
-  let i = 0;
   let species = '';
   let s = '';
+  let inCC = false;
+  let ccLine = 0;
+  let sectionLines = 0;
+  let prevSectionEmpty = false;
   for (const line of report.split('\n')) {
-    i++;
-    if (line.startsWith(' +')) {
-      section++;
-      i = 0;
+    // Old format (pre-2026-03): section separators start with ' +', new format starts with '+'
+    if (line.trimStart().startsWith('+')) {
+      prevSectionEmpty = sectionLines === 0;
+      inCC = false;
+      ccLine = 0;
+      sectionLines = 0;
       continue;
     }
-    if (section % 10 === 1) {
-      species = line.slice(3, line.indexOf('  '));
+    sectionLines++;
+    if (line.includes('Checks and Counters')) {
+      inCC = true;
+      ccLine = 0;
+      continue;
     }
-    if (section % 10 === 2 && i === 2) {
-      movesets[species] = {weight: Number(line.slice(17, line.indexOf(' ', 17))), outcomes: {}};
+    if (sectionLines === 1 && prevSectionEmpty) {
+      species = line.split('|')[1]?.trim() ?? '';
+      continue;
     }
-    if (section % 10 === 9 && i >= 2) {
-      if (i % 2 === 0) {
+    if (!movesets[species] && line.includes('Avg. weight')) {
+      movesets[species] = {weight: Number((/\d[\d.]*/.exec(line))?.[0]), outcomes: {}};
+      continue;
+    }
+    if (inCC) {
+      ccLine++;
+      if (ccLine % 2 === 1) {
         s = SPECIES.exec(line)![1];
       } else {
         const outcome = OUTCOME.exec(line)!;
@@ -468,16 +481,17 @@ function partialParseMovesetReport(report: string) {
   return movesets;
 }
 
-function parseMetagameReport(report: string) {
+export function parseMetagameReport(report: string) {
   const tags: {[tag: string]: number} = {};
   const lines = report.split('\n');
 
   let i = 0;
   for (; i < lines.length; i++) {
-    const d = lines[i].indexOf('.');
+    const line = lines[i].trimStart();
+    const d = line.indexOf('.');
     if (d < 0) break;
-    const tag = lines[i].slice(1, d);
-    const weight = Number(lines[i].slice(lines[i].search(/\d/), lines[i].lastIndexOf('%'))) / 100;
+    const tag = line.slice(0, d);
+    const weight = Number(line.slice(line.search(/\d/), line.lastIndexOf('%'))) / 100;
     tags[tag] = weight;
   }
   i++;

--- a/stats/src/test/display.test.ts
+++ b/stats/src/test/display.test.ts
@@ -1,4 +1,6 @@
-import {Display, parseLeadsReport, parseUsageReport} from '../display';
+import {
+  Display, parseLeadsReport, parseMetagameReport, parseUsageReport, partialParseMovesetReport,
+} from '../display';
 
 // Old format: leading space on header lines, Real column has actual values.
 // New format (introduced 2026-03): no leading space, Real column is always 0.
@@ -143,6 +145,148 @@ const mockGen = {
   items: {get: () => undefined},
   moves: {get: () => undefined},
 } as any;
+
+// Moveset report format changed in 2026-03: section separators and data lines lost their
+// leading space. This broke section counting, species name extraction, and weight parsing.
+// https://www.smogon.com/stats/2026-02/moveset/gen9ou-1825.txt (old)
+// https://www.smogon.com/stats/2026-03/moveset/gen9ou-1825.txt (new)
+
+// 9 content separators + 1 end separator = 10 per block (old format always had Tera Types)
+const OLD_MOVESET = [
+  ' +---+',
+  ' | Snorlax  |',
+  ' +---+',
+  ' | Raw count: 2  |',
+  ' | Avg. weight: 0.75  |',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' +---+',
+  ' | Checks and Counters |',
+  ' | Tauros 1.0 (1.00±0.00) |',
+  ' |  (50.0% KOed / 25.0% switched out) |',
+].join('\n');
+
+const NEW_MOVESET = [
+  '+---+',
+  '| Snorlax  |',
+  '+---+',
+  '| Raw count: 2  |',
+  '| Avg. weight: 0.75  |',
+  '+---+',
+  '+---+',
+  '+---+',
+  '+---+',
+  '+---+',
+  '+---+',
+  '+---+',
+  '| Checks and Counters |',
+  '| Tauros 1.0 (1.00±0.00) |',
+  '|\t(50.0% KOed / 25.0% switched out)',
+].join('\n');
+
+describe('partialParseMovesetReport', () => {
+  test('old format (leading space) — species, weight, and outcomes parsed correctly', () => {
+    const r = partialParseMovesetReport(OLD_MOVESET);
+    expect(Object.keys(r)).toEqual(['Snorlax']);
+    expect(r['Snorlax'].weight).toBeCloseTo(0.75);
+    expect(r['Snorlax'].outcomes['Tauros']).toMatchObject({
+      koedn: expect.closeTo(0.5),
+      switchedn: expect.closeTo(0.25),
+    });
+  });
+
+  test('new format (2026-03+) — species, weight, and outcomes parsed correctly', () => {
+    const r = partialParseMovesetReport(NEW_MOVESET);
+    expect(Object.keys(r)).toEqual(['Snorlax']);
+    expect(r['Snorlax'].weight).toBeCloseTo(0.75);
+    expect(r['Snorlax'].outcomes['Tauros']).toMatchObject({
+      koedn: expect.closeTo(0.5),
+      switchedn: expect.closeTo(0.25),
+    });
+  });
+
+  test('old and new format produce identical results for equivalent data', () => {
+    const old = partialParseMovesetReport(OLD_MOVESET);
+    const neo = partialParseMovesetReport(NEW_MOVESET);
+    expect(neo).toEqual(old);
+  });
+
+  test('weight >= 1 is parsed correctly (old slice(17) would give wrong result)', () => {
+    const report = OLD_MOVESET.replace('Avg. weight: 0.75', 'Avg. weight: 1.5');
+    const r = partialParseMovesetReport(report);
+    expect(r['Snorlax'].weight).toBeCloseTo(1.5);
+  });
+});
+
+// Metagame report format changed in 2026-03: old format has a leading space on tag lines,
+// new format does not. Both must produce identical keys (no truncated first character).
+// https://www.smogon.com/stats/2026-02/metagame/gen9ou-1825.txt (old)
+// https://www.smogon.com/stats/2026-03/metagame/gen9ou-1825.txt (new)
+
+const OLD_METAGAME = [
+  ' weatherless...................84.96715%',
+  ' offense.......................38.05594%',
+  ' balance.......................30.04767%',
+  ' hyperoffense..................13.71165%',
+  ' trickroom..................... 0.49318%',
+  '',
+  ' Stalliness (mean:  0.108)',
+  ' -1.0|##',
+  '     |###',
+  ' -0.5|####',
+  '     |#####',
+  '  0.0|######',
+  ' more negative = more offensive, more positive = more stall',
+  ' one # =  0.35%',
+].join('\n');
+
+const NEW_METAGAME = [
+  'weatherless.......88.37742%',
+  'offense...........36.34664%',
+  'balance...........36.40463%',
+  'hyperoffense......10.25606%',
+  'trickroom.........0.54911%',
+  '',
+  'Stalliness (mean: 0.189)',
+  '    |',
+  '-1.0|##',
+  '    |###',
+  '-0.5|####',
+  '    |#####',
+  ' 0.0|######',
+  'more negative = more offensive, more positive = more stall',
+  'one # = 0.42%',
+].join('\n');
+
+describe('parseMetagameReport', () => {
+  test('old format (leading space on tag lines) — keys are not truncated', () => {
+    const r = parseMetagameReport(OLD_METAGAME);
+    expect(Object.keys(r.tags))
+      .toEqual(['weatherless', 'offense', 'balance', 'hyperoffense', 'trickroom']);
+    expect(r.tags['weatherless']).toBeCloseTo(0.8496715);
+    expect(r.tags['offense']).toBeCloseTo(0.3805594);
+    expect(r.mean).toBeCloseTo(0.108);
+  });
+
+  test('new format (no leading space, 2026-03+) — keys are not truncated', () => {
+    const r = parseMetagameReport(NEW_METAGAME);
+    expect(Object.keys(r.tags))
+      .toEqual(['weatherless', 'offense', 'balance', 'hyperoffense', 'trickroom']);
+    expect(r.tags['weatherless']).toBeCloseTo(0.8837742);
+    expect(r.tags['balance']).toBeCloseTo(0.3640463);
+    expect(r.mean).toBeCloseTo(0.189);
+  });
+
+  test('old and new format produce the same tag keys for equivalent data', () => {
+    const oldResult = parseMetagameReport(OLD_METAGAME);
+    const newResult = parseMetagameReport(NEW_METAGAME);
+    expect(Object.keys(oldResult.tags)).toEqual(Object.keys(newResult.tags));
+  });
+});
 
 // Checks and Counters format changed in 2026-03 from [n, p, d] arrays to {n, p, d} objects.
 // https://www.smogon.com/stats/2026-02/chaos/gen9ou-1825.json (old)


### PR DESCRIPTION
I think this should fix all the issues that #26 didn't catch.

Same as usual, tests are red before, green after.
